### PR TITLE
Make sure list items are previewed when added

### DIFF
--- a/js/preview/imagechooserblock.js
+++ b/js/preview/imagechooserblock.js
@@ -9,6 +9,12 @@ class ImageChooserPreview extends Preview {
 
   getValue() {
     const previewImage = this.state?.preview
+    if (!previewImage) {
+      return {
+        alt: "empty image"
+      }
+    }
+
     return {
       src: previewImage.url,
       width: previewImage.width,
@@ -18,8 +24,10 @@ class ImageChooserPreview extends Preview {
   }
 
   setState(newState) {
-    this.state = newState
-    $(`#${this.prefix}`).attr(this.getValue())
+    if (newState) {
+      this.state = newState
+      $(`#${this.prefix}`).attr(this.getValue())
+    }
   }
 
   render(previewPlaceholder, prefix, initialState, initialError) {
@@ -27,7 +35,7 @@ class ImageChooserPreview extends Preview {
 
     return renderInPlaceHolder(previewPlaceholder, (
       <Fragment>
-        {previewImage ? <img id={prefix} {...this.getValue()} /> : "empty image"}
+      <img id={prefix} {...this.getValue()} />
         <PlaceHolder/>
       </Fragment>
     ))

--- a/js/preview/listblock.js
+++ b/js/preview/listblock.js
@@ -1,4 +1,5 @@
 import dom, { Fragment } from 'jsx-render'
+import { v4 as uuidv4 } from 'uuid'
 import { renderInPlaceHolder, PlaceHolder } from "../jsx"
 import { Preview, renderPreview } from "./render"
 import "./listblock.scss"
@@ -7,10 +8,21 @@ import "./listblock.scss"
 class ListBlockPreview extends Preview {
   setState(newState) {
     this.state = newState
-    const { children } = this
+    const { children=[] } = this
     const values = this.getValue()
-    for (let i = 0; i < children.length; i++) {
-      children[i].setState(values[i])
+    const numValues = values.length
+
+    for (let i = 0; i < numValues; i++) {
+      if (i < children.length) {
+        children[i].setState(values[i])
+      } else {
+        const childState = values[i]
+        // generate an id because they need to be unique per item.
+        childState.id = `listitem-preview-${uuidv4()}`
+        const { child, childPlaceholder } = this.renderChild(this.childPlaceholder, childState)
+        this.childPlaceholder = childPlaceholder
+        this.children.push(child)
+      }
     }
   }
 
@@ -18,8 +30,14 @@ class ListBlockPreview extends Preview {
     return this.state.map(state => state.value)
   }
 
+  renderChild(placeholder, childState) {
+    const child = renderPreview(this.blockDef.childBlockDef, placeholder, `preview-${childState.id}`, childState.value)
+    const childPlaceholder = child.placeholder
+    return { child, childPlaceholder}
+  }
+
   render(previewPlaceholder, prefix, initialState, initialError) {
-    const { element, placeholders: [childPlaceholder, placeholder] } = renderInPlaceHolder(previewPlaceholder, (
+    const { element, placeholders: [initialChildPlaceholder, placeholder] } = renderInPlaceHolder(previewPlaceholder, (
       <Fragment>
         <div className="preview-listblock">
           <PlaceHolder/>
@@ -28,10 +46,10 @@ class ListBlockPreview extends Preview {
       </Fragment>
     ))
 
-    let nextChildPlaceholder = childPlaceholder
+    this.childPlaceholder = initialChildPlaceholder
     this.children = initialState.map(childState => {
-      const child = renderPreview(this.blockDef.childBlockDef, nextChildPlaceholder, `preview-${childState.id}`, childState.value)
-      nextChildPlaceholder = child.placeholder
+      const { child, childPlaceholder } = this.renderChild(this.childPlaceholder, childState)
+      this.childPlaceholder = childPlaceholder
       return child
     })
 

--- a/js/preview/render.js
+++ b/js/preview/render.js
@@ -27,15 +27,20 @@ export class Preview {
   }
 
   getValue() {
-    const { meta: { label }} = this.blockDef
-    const [firstStateValue] = Object.values(this.state)
-
+    const { meta: { label=null }} = this.blockDef
     let previewValue = label
+
     try {
-      previewValue = stripHtml(firstStateValue.toString()).result || label
+      const [firstStateValue] = Object.values(this.state)
+
+      if (firstStateValue) {
+        previewValue = stripHtml(firstStateValue.toString()).result || label
+      }
     } catch {
-      previewValue = label || firstStateValue ? firstStateValue.toString() : "Empty"
+      // we don't care what happened, we just where unable to convert the
+      // firstStateValue into a string.
     }
+
     return previewValue
   }
 
@@ -89,7 +94,7 @@ export class TemplatePreview extends Preview {
             this.children[childBlockDef.name] = childBlockDef.renderPreview(
               childBlockElement,
               prefix + '-' + childBlockDef.name,
-              initialState[childBlockDef.name],
+              initialState? initialState[childBlockDef.name] : "",
               initialError?.blockErrors[childBlockDef.name]
             )
           }

--- a/js/preview/streamblock.js
+++ b/js/preview/streamblock.js
@@ -133,8 +133,8 @@ class PreviewStreamChild extends getStreamChild() {
     super.setError(error)
     this.blockDef.setError(error)
   }
-  collapse() { /* we don't want this */ }
-  expand() { /* we don't want this either */ }
+  collapse() { /* we don't need this functionality */ }
+  expand() { /* we don't need this functionality either */ }
 }
 
 class PreviewStreamBlock extends window.wagtailStreamField.blocks.StreamBlock {


### PR DESCRIPTION
When a block is a listblock, new items are immediately added to the preview instead of being only visible after save